### PR TITLE
Fix issue 57: convert hf.end.na to numeric to avoid 'non-intersecting series' error

### DIFF
--- a/R/ta.R
+++ b/R/ta.R
@@ -96,7 +96,7 @@ SubAggregation <- function(x, conversion = "sum", f_l = 1) {
   hf.start <- time(x)[!is.na(x)][1]
   hf.start.na <- time(x)[1]
   hf.end <- tail(time(x)[!is.na(x)], 1)
-  hf.end.na <- tail(time(x), 1)
+  hf.end.na <- c(tail(time(x), 1))
 
   lf.start <- SubConvertStart(hf.start = hf.start, f = f, f_l = f_l)
   lf.start.na <- SubConvertStart(hf.start = hf.start.na, f = f, f_l = f_l)

--- a/tests/testthat/test_ta.R
+++ b/tests/testthat/test_ta.R
@@ -1,0 +1,4 @@
+test_that("ta works", {
+  x <- ts(rep(1, 23), frequency = 12, start = c(2000, 2))
+  expect_equal(ta(x, to = "annual", conversion = "sum"), ts(12, start = 2001))
+})


### PR DESCRIPTION
Adds in #57 suggested fix and a unit test:

```r
hf.end.na <- c(tail(time(x), 1))
```